### PR TITLE
limit jsonschema dependency version to last known working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "escape-string-regexp": "^1.0.5",
     "extend": "^3.0.0",
     "json-buffer": "~2.0.11",
-    "jsonschema": "^1.0.3",
+    "jsonschema": ">=1.0.3 <1.2.7",
     "level-sublevel": "^6.5.2",
     "levelup": "^1.3.8",
     "lru-cache": "~4.0.0",


### PR DESCRIPTION
https://stackoverflow.com/questions/64189045/node-js-mosca-broker-error-expected-schema-to-be-an-object-or-boolean